### PR TITLE
[Fix] Remove sudo from NVIDIA runtime commands

### DIFF
--- a/tutorials/docker/NVIDIA-RUNTIME.md
+++ b/tutorials/docker/NVIDIA-RUNTIME.md
@@ -33,8 +33,8 @@ gpus: all
    
 4. Now install the container toolkit:
     ```
-    sudo apt update
-    sudo apt install -y nvidia-container-toolkit
+    apt update
+    apt install -y nvidia-container-toolkit
     ```
 
 5. Configure docker to use the NVIDIA runtime:


### PR DESCRIPTION
- Remove sudo from commands where it has previously been stated to run as root.